### PR TITLE
Removed VACUUM from cleanup call

### DIFF
--- a/pkg/storage/sqlite.go
+++ b/pkg/storage/sqlite.go
@@ -126,7 +126,7 @@ func (s *Sqlite) Clean() (CleanResult, error) {
 	}
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	result, err := s.db.Exec("DELETE FROM ApiResponses WHERE expires < ?; VACUUM", time.Now().Unix())
+	result, err := s.db.Exec("DELETE FROM ApiResponses WHERE expires < ?", time.Now().Unix())
 	if err != nil {
 		return CleanResult{}, err
 	}


### PR DESCRIPTION
VACUUM is used to ensure the database shrinks in size after each cleaning. However, it appears to achieve this it ends up creating temporary files equal to the size of the database, causing an out-of-disk-space error.
 
While I could just increase the disk space being used, at this time I'd like to simply remove the call and see what happens to the DB size over time. Assuming space is recycled, the call may not be necessary.