### PR TITLE
Refactor: Move to a slightly more generic interface for scanning

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/monitor"
 	"github.com/crbednarz/moonkinmetrics/pkg/retrieve/seasons"
 	"github.com/crbednarz/moonkinmetrics/pkg/retrieve/talents"
@@ -25,7 +25,7 @@ import (
 )
 
 type bracketScanOptions struct {
-	Region    bnet.Region
+	Region    api.Region
 	Bracket   string
 	Output    string
 	MinRating uint
@@ -54,7 +54,7 @@ func runTalentScan(c *cli.Context) error {
 }
 
 func runLadderScan(c *cli.Context) error {
-	region := bnet.Region(c.String("region"))
+	region := api.Region(c.String("region"))
 
 	scanner, err := buildScanner(c)
 	if err != nil {
@@ -161,19 +161,19 @@ func scanBracket(scanner *scan.Scanner, trees []wow.TalentTree, options bracketS
 func buildScanner(c *cli.Context) (*scan.Scanner, error) {
 	offline := c.Bool("offline")
 
-	var httpClient bnet.HttpClient
+	var httpClient api.HttpClient
 	if offline {
-		httpClient = &bnet.OfflineHttpClient{}
+		httpClient = &api.OfflineHttpClient{}
 	} else {
 		httpClient = &http.Client{}
 	}
-	client := bnet.NewClient(
+	client := api.NewClient(
 		httpClient,
-		bnet.WithCredentials(
+		api.WithCredentials(
 			c.String("client-id"),
 			c.String("client-secret"),
 		),
-		bnet.WithLimiter(!offline),
+		api.WithLimiter(!offline),
 	)
 
 	if !offline {

--- a/cmd/testgen/gen.go
+++ b/cmd/testgen/gen.go
@@ -89,7 +89,7 @@ func downloadTalentResponses(client *api.Client, scanner *scan.Scanner) error {
 }
 
 func downloadRequest(client *api.Client, request api.BnetRequest) error {
-	response, err := client.Get(request)
+	response, err := client.Get(&request)
 	if err != nil {
 		return err
 	}

--- a/cmd/testgen/gen.go
+++ b/cmd/testgen/gen.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/retrieve/talents"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/storage"
@@ -18,13 +18,13 @@ func main() {
 
 	httpClient := &http.Client{}
 
-	client := bnet.NewClient(
+	client := api.NewClient(
 		httpClient,
-		bnet.WithCredentials(
+		api.WithCredentials(
 			os.Getenv("WOW_CLIENT_ID"),
 			os.Getenv("WOW_CLIENT_SECRET"),
 		),
-		bnet.WithLimiter(true),
+		api.WithLimiter(true),
 	)
 
 	err := client.Authenticate()
@@ -50,14 +50,14 @@ func main() {
 	log.Printf("Test data generated")
 }
 
-func downloadTalentResponses(client *bnet.Client, scanner *scan.Scanner) error {
+func downloadTalentResponses(client *api.Client, scanner *scan.Scanner) error {
 	index, err := talents.GetTalentTreeIndex(scanner)
 	if err != nil {
 		return err
 	}
 
 	for _, specLink := range index.SpecLinks {
-		request, err := bnet.RequestFromUrl(specLink.Url)
+		request, err := api.RequestFromUrl(specLink.Url)
 		if err != nil {
 			return err
 		}
@@ -75,9 +75,9 @@ func downloadTalentResponses(client *bnet.Client, scanner *scan.Scanner) error {
 	}
 
 	for _, path := range staticAssets {
-		err = downloadRequest(client, bnet.Request{
-			Region:    bnet.RegionUS,
-			Namespace: bnet.NamespaceStatic,
+		err = downloadRequest(client, api.Request{
+			Region:    api.RegionUS,
+			Namespace: api.NamespaceStatic,
 			Path:      path,
 		})
 		if err != nil {
@@ -88,7 +88,7 @@ func downloadTalentResponses(client *bnet.Client, scanner *scan.Scanner) error {
 	return nil
 }
 
-func downloadRequest(client *bnet.Client, request bnet.Request) error {
+func downloadRequest(client *api.Client, request api.Request) error {
 	response, err := client.Get(request)
 	if err != nil {
 		return err

--- a/cmd/testgen/gen.go
+++ b/cmd/testgen/gen.go
@@ -75,7 +75,7 @@ func downloadTalentResponses(client *api.Client, scanner *scan.Scanner) error {
 	}
 
 	for _, path := range staticAssets {
-		err = downloadRequest(client, api.Request{
+		err = downloadRequest(client, api.BnetRequest{
 			Region:    api.RegionUS,
 			Namespace: api.NamespaceStatic,
 			Path:      path,
@@ -88,7 +88,7 @@ func downloadTalentResponses(client *api.Client, scanner *scan.Scanner) error {
 	return nil
 }
 
-func downloadRequest(client *api.Client, request api.Request) error {
+func downloadRequest(client *api.Client, request api.BnetRequest) error {
 	response, err := client.Get(request)
 	if err != nil {
 		return err

--- a/pkg/api/bnet.go
+++ b/pkg/api/bnet.go
@@ -26,7 +26,7 @@ const (
 )
 
 // A WoW API request.
-type Request struct {
+type BnetRequest struct {
 	Path      string
 	Region    Region
 	Namespace Namespace
@@ -35,17 +35,17 @@ type Request struct {
 // Creates a WoW API request from the given URL.
 // The URL is expected to be in the format returned by the WoW API.
 // e.g. https://us.api.blizzard.com/data/wow/talents?namespace=static-10.1.7_51059-us
-func RequestFromUrl(rawUrl string) (Request, error) {
+func RequestFromUrl(rawUrl string) (BnetRequest, error) {
 	matches := urlRegex.FindStringSubmatch(rawUrl)
 	if len(matches) != 4 {
-		return Request{}, fmt.Errorf("invalid url: %s", rawUrl)
+		return BnetRequest{}, fmt.Errorf("invalid url: %s", rawUrl)
 	}
 
 	region := Region(matches[1])
 	path := matches[2]
 	namespace := Namespace(matches[3])
 
-	return Request{
+	return BnetRequest{
 		Path:      path,
 		Region:    region,
 		Namespace: namespace,
@@ -54,7 +54,7 @@ func RequestFromUrl(rawUrl string) (Request, error) {
 
 // Returns the url.URL representation of the WoW API request.
 // This does not include the authorization header, so is typically used for logging.
-func (r *Request) Url() *url.URL {
+func (r *BnetRequest) Url() *url.URL {
 	locale := "en_US"
 	if r.Region == RegionEU {
 		locale = "en_GB"
@@ -74,13 +74,13 @@ func (r *Request) Url() *url.URL {
 
 // Returns the string representation of the WoW API request.
 // This is equivalent to Url().String().
-func (r *Request) String() string {
+func (r *BnetRequest) String() string {
 	return r.Url().String()
 }
 
 // Creates an http.Request from the WoW API request with the given token.
 // This includes the authorization header, unlike Url() and String().
-func (r *Request) HttpRequest(token string) (*http.Request, error) {
+func (r *BnetRequest) HttpRequest(token string) (*http.Request, error) {
 	request, err := http.NewRequest("GET", r.String(), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/api/bnet_test.go
+++ b/pkg/api/bnet_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRequestToString(t *testing.T) {
-	request := Request{
+	request := BnetRequest{
 		Path:      "/data/wow/pvp-season/35/pvp-leaderboard/3v3",
 		Namespace: NamespaceDynamic,
 		Region:    RegionUS,
@@ -24,7 +24,7 @@ func TestRequestToString(t *testing.T) {
 }
 
 func TestRequestToUrl(t *testing.T) {
-	request := Request{
+	request := BnetRequest{
 		Path:      "/data/wow/pvp-season/35/pvp-leaderboard/3v3",
 		Namespace: NamespaceDynamic,
 		Region:    RegionUS,
@@ -42,7 +42,7 @@ func TestRequestToUrl(t *testing.T) {
 }
 
 func TestRequestToHttpRequest(t *testing.T) {
-	request := Request{
+	request := BnetRequest{
 		Path:      "/data/wow/pvp-season/35/pvp-leaderboard/3v3",
 		Namespace: NamespaceDynamic,
 		Region:    RegionUS,
@@ -78,7 +78,7 @@ func TestRequestToHttpRequest(t *testing.T) {
 
 func TestRequestFromUrl(t *testing.T) {
 	rawUrl := "https://us.api.blizzard.com/data/wow/talent-tree/850?namespace=static-10.1.7_51059-us"
-	expected := Request{
+	expected := BnetRequest{
 		Path:      "/data/wow/talent-tree/850",
 		Namespace: NamespaceStatic,
 		Region:    RegionUS,

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -1,4 +1,4 @@
-package bnet
+package api
 
 import (
 	"context"

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -31,7 +31,7 @@ type Client struct {
 }
 
 type clientOptions struct {
-	bnetCredentialsOption
+	credentialsOption
 	limiterOption
 }
 
@@ -49,17 +49,17 @@ func WithLimiter(l bool) ClientOption {
 	return limiterOption(l)
 }
 
-type bnetCredentialsOption struct {
+type credentialsOption struct {
 	clientId     string
 	clientSecret string
 }
 
-func (b bnetCredentialsOption) apply(o *clientOptions) {
-	o.bnetCredentialsOption = b
+func (b credentialsOption) apply(o *clientOptions) {
+	o.credentialsOption = b
 }
 
 func WithCredentials(clientId, clientSecret string) ClientOption {
-	return bnetCredentialsOption{
+	return credentialsOption{
 		clientId:     clientId,
 		clientSecret: clientSecret,
 	}
@@ -86,7 +86,7 @@ func NewClient(client HttpClient, opts ...ClientOption) *Client {
 	}
 }
 
-func (c *Client) Get(request BnetRequest) (*Response, error) {
+func (c *Client) Get(request Request) (*Response, error) {
 	var response *http.Response
 	var err error
 	attempts := 0
@@ -125,13 +125,12 @@ func (c *Client) Get(request BnetRequest) (*Response, error) {
 
 	return &Response{
 		Body:       body,
-		Request:    &request,
 		StatusCode: response.StatusCode,
 		Attempts:   attempts,
 	}, err
 }
 
-func (c *Client) doAuthenticatedRequest(request BnetRequest) (*http.Response, error) {
+func (c *Client) doAuthenticatedRequest(request Request) (*http.Response, error) {
 	needsReauthentication := false
 	var token string
 	for {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -86,7 +86,7 @@ func NewClient(client HttpClient, opts ...ClientOption) *Client {
 	}
 }
 
-func (c *Client) Get(request Request) (*Response, error) {
+func (c *Client) Get(request BnetRequest) (*Response, error) {
 	var response *http.Response
 	var err error
 	attempts := 0
@@ -131,7 +131,7 @@ func (c *Client) Get(request Request) (*Response, error) {
 	}, err
 }
 
-func (c *Client) doAuthenticatedRequest(request Request) (*http.Response, error) {
+func (c *Client) doAuthenticatedRequest(request BnetRequest) (*http.Response, error) {
 	needsReauthentication := false
 	var token string
 	for {

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -97,7 +97,7 @@ func TestClientCanGet(t *testing.T) {
 	)
 	client.Authenticate()
 
-	response, err := client.Get(request)
+	response, err := client.Get(&request)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -129,7 +129,7 @@ func TestClientReauthenticates(t *testing.T) {
 	client.Authenticate()
 
 	for i := 0; i < 4; i++ {
-		response, err := client.Get(request)
+		response, err := client.Get(&request)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -85,7 +85,7 @@ func (m *MockHttpClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 func TestClientCanGet(t *testing.T) {
-	request := Request{
+	request := BnetRequest{
 		Region:    RegionUS,
 		Namespace: NamespaceProfile,
 		Path:      "/data/wow/mock/path",
@@ -112,7 +112,7 @@ func TestClientCanGet(t *testing.T) {
 }
 
 func TestClientReauthenticates(t *testing.T) {
-	request := Request{
+	request := BnetRequest{
 		Region:    RegionUS,
 		Namespace: NamespaceProfile,
 		Path:      "/data/wow/mock/path",

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -1,4 +1,4 @@
-package bnet
+package api
 
 import (
 	"fmt"

--- a/pkg/api/offline.go
+++ b/pkg/api/offline.go
@@ -1,4 +1,4 @@
-package bnet
+package api
 
 import (
 	"io"

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -1,4 +1,4 @@
-package bnet
+package api
 
 import (
 	"fmt"
@@ -7,8 +7,10 @@ import (
 	"regexp"
 )
 
-type Namespace string
-type Region string
+type (
+	Namespace string
+	Region    string
+)
 
 const (
 	NamespaceStatic  Namespace = "static"
@@ -16,9 +18,7 @@ const (
 	NamespaceProfile Namespace = "profile"
 )
 
-var (
-	urlRegex = regexp.MustCompile(`^https?:\/\/(us|eu)\.api\.blizzard\.com(\/[^?]+)\?.*namespace=(static|dynamic|profile)-.+$`)
-)
+var urlRegex = regexp.MustCompile(`^https?:\/\/(us|eu)\.api\.blizzard\.com(\/[^?]+)\?.*namespace=(static|dynamic|profile)-.+$`)
 
 const (
 	RegionUS Region = "us"

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -1,0 +1,7 @@
+package api
+
+import "net/http"
+
+type Request interface {
+	HttpRequest(token string) (*http.Request, error)
+}

--- a/pkg/api/request_test.go
+++ b/pkg/api/request_test.go
@@ -1,4 +1,4 @@
-package bnet
+package api
 
 import (
 	"net/url"

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -2,7 +2,7 @@ package api
 
 type Response struct {
 	Body       []byte
-	Request    *Request
+	Request    *BnetRequest
 	StatusCode int
 	Attempts   int
 }

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -2,7 +2,6 @@ package api
 
 type Response struct {
 	Body       []byte
-	Request    *BnetRequest
 	StatusCode int
 	Attempts   int
 }

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -1,4 +1,4 @@
-package bnet
+package api
 
 type Response struct {
 	Body       []byte

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/crbednarz/moonkinmetrics/pkg/wow"
+)
+
+func ExpandBracketArg(arg string) []string {
+	brackets := []string{arg}
+	if arg == "shuffle" || arg == "blitz" {
+		brackets = make([]string, 0, len(wow.SpecByClass)*3)
+		for class, specs := range wow.SpecByClass {
+			classSlug := strings.ReplaceAll(class, " ", "")
+			for _, spec := range specs {
+				specSlug := strings.ReplaceAll(spec, " ", "")
+				slug := strings.ToLower(fmt.Sprintf("%s-%s-%s", arg, classSlug, specSlug))
+				brackets = append(brackets, slug)
+			}
+		}
+	}
+	return brackets
+}

--- a/pkg/retrieve/players/realms.go
+++ b/pkg/retrieve/players/realms.go
@@ -26,7 +26,7 @@ func GetRealms(scanner *scan.Scanner, realmLinks []wow.RealmLink) ([]wow.Realm, 
 		return nil, fmt.Errorf("failed to setup realm validator: %w", err)
 	}
 
-	requests := make(chan api.Request, len(realmLinks))
+	requests := make(chan api.BnetRequest, len(realmLinks))
 	results := make(chan scan.ScanResult[realmJson], len(realmLinks))
 	options := scan.ScanOptions[realmJson]{
 		Validator: validator,

--- a/pkg/retrieve/players/realms.go
+++ b/pkg/retrieve/players/realms.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/validate"
 	"github.com/crbednarz/moonkinmetrics/pkg/wow"
@@ -26,7 +26,7 @@ func GetRealms(scanner *scan.Scanner, realmLinks []wow.RealmLink) ([]wow.Realm, 
 		return nil, fmt.Errorf("failed to setup realm validator: %w", err)
 	}
 
-	requests := make(chan bnet.Request, len(realmLinks))
+	requests := make(chan api.Request, len(realmLinks))
 	results := make(chan scan.ScanResult[realmJson], len(realmLinks))
 	options := scan.ScanOptions[realmJson]{
 		Validator: validator,
@@ -37,7 +37,7 @@ func GetRealms(scanner *scan.Scanner, realmLinks []wow.RealmLink) ([]wow.Realm, 
 	scan.Scan(scanner, requests, results, &options)
 
 	for _, realmLink := range realmLinks {
-		request, err := bnet.RequestFromUrl(realmLink.Url)
+		request, err := api.RequestFromUrl(realmLink.Url)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request from realm link [%v]: %w", realmLink.Url, err)
 		}

--- a/pkg/retrieve/players/specialization.go
+++ b/pkg/retrieve/players/specialization.go
@@ -140,7 +140,7 @@ func GetPlayerLoadouts(scanner *scan.Scanner, players []wow.PlayerLink, opts ...
 		opt.apply(&scanOptions)
 	}
 
-	requests := make(chan api.Request, len(players))
+	requests := make(chan api.BnetRequest, len(players))
 	results := make(chan scan.ScanResult[specializationsJson], len(players))
 	options := scan.ScanOptions[specializationsJson]{
 		Validator: validate.NewTagValidator[specializationsJson](),
@@ -150,7 +150,7 @@ func GetPlayerLoadouts(scanner *scan.Scanner, players []wow.PlayerLink, opts ...
 
 	scan.Scan(scanner, requests, results, &options)
 	for _, player := range players {
-		requests <- api.Request{
+		requests <- api.BnetRequest{
 			Region:    scanOptions.Region,
 			Namespace: api.NamespaceProfile,
 			Path:      player.SpecializationUrl(),

--- a/pkg/retrieve/seasons/index.go
+++ b/pkg/retrieve/seasons/index.go
@@ -55,7 +55,7 @@ func GetSeasonsIndex(scanner *scan.Scanner, region api.Region) (SeasonsIndex, er
 	}
 	result := scan.ScanSingle(
 		scanner,
-		api.Request{
+		api.BnetRequest{
 			Region:    region,
 			Namespace: api.NamespaceDynamic,
 			Path:      "/data/wow/pvp-season/index",

--- a/pkg/retrieve/seasons/index.go
+++ b/pkg/retrieve/seasons/index.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/validate"
 )
@@ -39,7 +39,7 @@ type keyJson struct {
 	Href string `json:"href"`
 }
 
-func GetCurrentSeasonId(scanner *scan.Scanner, region bnet.Region) (int, error) {
+func GetCurrentSeasonId(scanner *scan.Scanner, region api.Region) (int, error) {
 	index, err := GetSeasonsIndex(scanner, region)
 	if err != nil {
 		return -1, err
@@ -48,16 +48,16 @@ func GetCurrentSeasonId(scanner *scan.Scanner, region bnet.Region) (int, error) 
 	return index.CurrentSeason.Id, nil
 }
 
-func GetSeasonsIndex(scanner *scan.Scanner, region bnet.Region) (SeasonsIndex, error) {
+func GetSeasonsIndex(scanner *scan.Scanner, region api.Region) (SeasonsIndex, error) {
 	validator, err := validate.NewSchemaValidator[seasonsIndexJson](seasonsIndexSchema)
 	if err != nil {
 		return SeasonsIndex{}, fmt.Errorf("failed to setup seasons index validator: %w", err)
 	}
 	result := scan.ScanSingle(
 		scanner,
-		bnet.Request{
+		api.Request{
 			Region:    region,
-			Namespace: bnet.NamespaceDynamic,
+			Namespace: api.NamespaceDynamic,
 			Path:      "/data/wow/pvp-season/index",
 		},
 		&scan.ScanOptions[seasonsIndexJson]{

--- a/pkg/retrieve/seasons/index_test.go
+++ b/pkg/retrieve/seasons/index_test.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"testing"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/testutils"
 )
 
@@ -25,7 +25,7 @@ func TestGetSeasonsIndex(t *testing.T) {
 		t.Fatalf("failed to setup scanner: %v", err)
 	}
 
-	index, err := GetSeasonsIndex(scanner, bnet.RegionUS)
+	index, err := GetSeasonsIndex(scanner, api.RegionUS)
 	if err != nil {
 		t.Fatalf("failed to get pvp seasons index: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestGetSeasonsIndexFailOnMissingData(t *testing.T) {
 		t.Fatalf("failed to setup scanner: %v", err)
 	}
 
-	_, err = GetSeasonsIndex(scanner, bnet.RegionUS)
+	_, err = GetSeasonsIndex(scanner, api.RegionUS)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}

--- a/pkg/retrieve/seasons/leaderboard.go
+++ b/pkg/retrieve/seasons/leaderboard.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/validate"
 	"github.com/crbednarz/moonkinmetrics/pkg/wow"
@@ -31,7 +31,7 @@ type leaderboardJson struct {
 	} `json:"entries"`
 }
 
-func GetCurrentLeaderboard(scanner *scan.Scanner, bracket string, region bnet.Region) (wow.Leaderboard, error) {
+func GetCurrentLeaderboard(scanner *scan.Scanner, bracket string, region api.Region) (wow.Leaderboard, error) {
 	seasonId, err := GetCurrentSeasonId(scanner, region)
 	if err != nil {
 		return wow.Leaderboard{}, fmt.Errorf("failed to get current season id: %w", err)
@@ -44,9 +44,9 @@ func GetCurrentLeaderboard(scanner *scan.Scanner, bracket string, region bnet.Re
 	path := fmt.Sprintf("/data/wow/pvp-season/%d/pvp-leaderboard/%s", seasonId, bracket)
 	result := scan.ScanSingle(
 		scanner,
-		bnet.Request{
+		api.Request{
 			Region:    region,
-			Namespace: bnet.NamespaceDynamic,
+			Namespace: api.NamespaceDynamic,
 			Path:      path,
 		},
 		&scan.ScanOptions[leaderboardJson]{

--- a/pkg/retrieve/seasons/leaderboard.go
+++ b/pkg/retrieve/seasons/leaderboard.go
@@ -44,7 +44,7 @@ func GetCurrentLeaderboard(scanner *scan.Scanner, bracket string, region api.Reg
 	path := fmt.Sprintf("/data/wow/pvp-season/%d/pvp-leaderboard/%s", seasonId, bracket)
 	result := scan.ScanSingle(
 		scanner,
-		api.Request{
+		api.BnetRequest{
 			Region:    region,
 			Namespace: api.NamespaceDynamic,
 			Path:      path,

--- a/pkg/retrieve/seasons/leaderboard_test.go
+++ b/pkg/retrieve/seasons/leaderboard_test.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"testing"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/testutils"
 )
@@ -34,7 +34,7 @@ func TestGetCurrentLeaderboard(t *testing.T) {
 		t.Fatalf("failed to setup scanner: %v", err)
 	}
 
-	leaderboard, err := GetCurrentLeaderboard(scanner, "3v3", bnet.RegionUS)
+	leaderboard, err := GetCurrentLeaderboard(scanner, "3v3", api.RegionUS)
 	if err != nil {
 		t.Fatalf("failed to get leaderboard: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestGetCurrentLeaderboardFailsOnBadData(t *testing.T) {
 		t.Fatalf("failed to setup scanner: %v", err)
 	}
 
-	_, err = GetCurrentLeaderboard(scanner, "3v3", bnet.RegionUS)
+	_, err = GetCurrentLeaderboard(scanner, "3v3", api.RegionUS)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}

--- a/pkg/retrieve/talents/index.go
+++ b/pkg/retrieve/talents/index.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/validate"
 )
@@ -58,9 +58,9 @@ func GetTalentTreeIndex(scanner *scan.Scanner) (*TalentTreeIndex, error) {
 
 	result := scan.ScanSingle(
 		scanner,
-		bnet.Request{
-			Region:    bnet.RegionUS,
-			Namespace: bnet.NamespaceStatic,
+		api.Request{
+			Region:    api.RegionUS,
+			Namespace: api.NamespaceStatic,
 			Path:      "/data/wow/talent-tree/index",
 		},
 		&scan.ScanOptions[treeIndexJson]{

--- a/pkg/retrieve/talents/index.go
+++ b/pkg/retrieve/talents/index.go
@@ -58,7 +58,7 @@ func GetTalentTreeIndex(scanner *scan.Scanner) (*TalentTreeIndex, error) {
 
 	result := scan.ScanSingle(
 		scanner,
-		api.Request{
+		api.BnetRequest{
 			Region:    api.RegionUS,
 			Namespace: api.NamespaceStatic,
 			Path:      "/data/wow/talent-tree/index",

--- a/pkg/retrieve/talents/ingame.go
+++ b/pkg/retrieve/talents/ingame.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/hack"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/validate"
@@ -112,7 +112,7 @@ func getTalentsJsonFromIds(scanner *scan.Scanner, talentIds []int) (map[int]tale
 		return nil, fmt.Errorf("failed to create talent validator: %v", err)
 	}
 
-	requests := make(chan bnet.Request, len(talentIds))
+	requests := make(chan api.Request, len(talentIds))
 	results := make(chan scan.ScanResult[talentJson], len(talentIds))
 	options := scan.ScanOptions[talentJson]{
 		Validator: validator,
@@ -121,9 +121,9 @@ func getTalentsJsonFromIds(scanner *scan.Scanner, talentIds []int) (map[int]tale
 
 	scan.Scan(scanner, requests, results, &options)
 	for _, talentId := range talentIds {
-		apiRequest := bnet.Request{
-			Region:    bnet.RegionUS,
-			Namespace: bnet.NamespaceStatic,
+		apiRequest := api.Request{
+			Region:    api.RegionUS,
+			Namespace: api.NamespaceStatic,
 			Path:      fmt.Sprintf("/data/wow/talent/%d", talentId),
 		}
 

--- a/pkg/retrieve/talents/ingame.go
+++ b/pkg/retrieve/talents/ingame.go
@@ -112,7 +112,7 @@ func getTalentsJsonFromIds(scanner *scan.Scanner, talentIds []int) (map[int]tale
 		return nil, fmt.Errorf("failed to create talent validator: %v", err)
 	}
 
-	requests := make(chan api.Request, len(talentIds))
+	requests := make(chan api.BnetRequest, len(talentIds))
 	results := make(chan scan.ScanResult[talentJson], len(talentIds))
 	options := scan.ScanOptions[talentJson]{
 		Validator: validator,
@@ -121,7 +121,7 @@ func getTalentsJsonFromIds(scanner *scan.Scanner, talentIds []int) (map[int]tale
 
 	scan.Scan(scanner, requests, results, &options)
 	for _, talentId := range talentIds {
-		apiRequest := api.Request{
+		apiRequest := api.BnetRequest{
 			Region:    api.RegionUS,
 			Namespace: api.NamespaceStatic,
 			Path:      fmt.Sprintf("/data/wow/talent/%d", talentId),

--- a/pkg/retrieve/talents/media.go
+++ b/pkg/retrieve/talents/media.go
@@ -23,7 +23,7 @@ type assetJson struct {
 func GetSpellMedia(scanner *scan.Scanner, trees []wow.TalentTree) (map[int]string, error) {
 	talentCount := countTalents(trees)
 
-	requests := make(chan api.Request, talentCount)
+	requests := make(chan api.BnetRequest, talentCount)
 	results := make(chan scan.ScanResult[spellMediaJson], talentCount)
 	options := scan.ScanOptions[spellMediaJson]{
 		Validator: nil,
@@ -37,7 +37,7 @@ func GetSpellMedia(scanner *scan.Scanner, trees []wow.TalentTree) (map[int]strin
 			node := &tree.ClassNodes[nodeIndex]
 			for talentIndex := range node.Talents {
 				talent := &node.Talents[talentIndex]
-				requests <- api.Request{
+				requests <- api.BnetRequest{
 					Region:    api.RegionUS,
 					Namespace: api.NamespaceStatic,
 					Path:      fmt.Sprintf("/data/wow/media/spell/%d", talent.Spell.Id),
@@ -48,7 +48,7 @@ func GetSpellMedia(scanner *scan.Scanner, trees []wow.TalentTree) (map[int]strin
 			node := &tree.SpecNodes[nodeIndex]
 			for talentIndex := range node.Talents {
 				talent := &node.Talents[talentIndex]
-				requests <- api.Request{
+				requests <- api.BnetRequest{
 					Region:    api.RegionUS,
 					Namespace: api.NamespaceStatic,
 					Path:      fmt.Sprintf("/data/wow/media/spell/%d", talent.Spell.Id),
@@ -57,7 +57,7 @@ func GetSpellMedia(scanner *scan.Scanner, trees []wow.TalentTree) (map[int]strin
 		}
 		for talentIndex := range tree.PvpTalents {
 			talent := &tree.PvpTalents[talentIndex]
-			requests <- api.Request{
+			requests <- api.BnetRequest{
 				Region:    api.RegionUS,
 				Namespace: api.NamespaceStatic,
 				Path:      fmt.Sprintf("/data/wow/media/spell/%d", talent.Spell.Id),
@@ -69,7 +69,7 @@ func GetSpellMedia(scanner *scan.Scanner, trees []wow.TalentTree) (map[int]strin
 			for nodeIndex := range heroTree.Nodes {
 				for talentIndex := range heroTree.Nodes[nodeIndex].Talents {
 					talent := &heroTree.Nodes[nodeIndex].Talents[talentIndex]
-					requests <- api.Request{
+					requests <- api.BnetRequest{
 						Region:    api.RegionUS,
 						Namespace: api.NamespaceStatic,
 						Path:      fmt.Sprintf("/data/wow/media/spell/%d", talent.Spell.Id),

--- a/pkg/retrieve/talents/media.go
+++ b/pkg/retrieve/talents/media.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/wow"
 )
@@ -23,7 +23,7 @@ type assetJson struct {
 func GetSpellMedia(scanner *scan.Scanner, trees []wow.TalentTree) (map[int]string, error) {
 	talentCount := countTalents(trees)
 
-	requests := make(chan bnet.Request, talentCount)
+	requests := make(chan api.Request, talentCount)
 	results := make(chan scan.ScanResult[spellMediaJson], talentCount)
 	options := scan.ScanOptions[spellMediaJson]{
 		Validator: nil,
@@ -37,9 +37,9 @@ func GetSpellMedia(scanner *scan.Scanner, trees []wow.TalentTree) (map[int]strin
 			node := &tree.ClassNodes[nodeIndex]
 			for talentIndex := range node.Talents {
 				talent := &node.Talents[talentIndex]
-				requests <- bnet.Request{
-					Region:    bnet.RegionUS,
-					Namespace: bnet.NamespaceStatic,
+				requests <- api.Request{
+					Region:    api.RegionUS,
+					Namespace: api.NamespaceStatic,
 					Path:      fmt.Sprintf("/data/wow/media/spell/%d", talent.Spell.Id),
 				}
 			}
@@ -48,18 +48,18 @@ func GetSpellMedia(scanner *scan.Scanner, trees []wow.TalentTree) (map[int]strin
 			node := &tree.SpecNodes[nodeIndex]
 			for talentIndex := range node.Talents {
 				talent := &node.Talents[talentIndex]
-				requests <- bnet.Request{
-					Region:    bnet.RegionUS,
-					Namespace: bnet.NamespaceStatic,
+				requests <- api.Request{
+					Region:    api.RegionUS,
+					Namespace: api.NamespaceStatic,
 					Path:      fmt.Sprintf("/data/wow/media/spell/%d", talent.Spell.Id),
 				}
 			}
 		}
 		for talentIndex := range tree.PvpTalents {
 			talent := &tree.PvpTalents[talentIndex]
-			requests <- bnet.Request{
-				Region:    bnet.RegionUS,
-				Namespace: bnet.NamespaceStatic,
+			requests <- api.Request{
+				Region:    api.RegionUS,
+				Namespace: api.NamespaceStatic,
 				Path:      fmt.Sprintf("/data/wow/media/spell/%d", talent.Spell.Id),
 			}
 		}
@@ -69,9 +69,9 @@ func GetSpellMedia(scanner *scan.Scanner, trees []wow.TalentTree) (map[int]strin
 			for nodeIndex := range heroTree.Nodes {
 				for talentIndex := range heroTree.Nodes[nodeIndex].Talents {
 					talent := &heroTree.Nodes[nodeIndex].Talents[talentIndex]
-					requests <- bnet.Request{
-						Region:    bnet.RegionUS,
-						Namespace: bnet.NamespaceStatic,
+					requests <- api.Request{
+						Region:    api.RegionUS,
+						Namespace: api.NamespaceStatic,
 						Path:      fmt.Sprintf("/data/wow/media/spell/%d", talent.Spell.Id),
 					}
 				}

--- a/pkg/retrieve/talents/pvp.go
+++ b/pkg/retrieve/talents/pvp.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/validate"
 	"github.com/crbednarz/moonkinmetrics/pkg/wow"
@@ -70,9 +70,9 @@ func getPvpTalentsIndex(scanner *scan.Scanner) (*pvpTalentsIndexJson, error) {
 
 	indexResult := scan.ScanSingle(
 		scanner,
-		bnet.Request{
-			Namespace: bnet.NamespaceStatic,
-			Region:    bnet.RegionUS,
+		api.Request{
+			Namespace: api.NamespaceStatic,
+			Region:    api.RegionUS,
 			Path:      "/data/wow/pvp-talent/index",
 		},
 		&scan.ScanOptions[pvpTalentsIndexJson]{
@@ -95,7 +95,7 @@ func getPvpTalentsFromIndex(scanner *scan.Scanner, index *pvpTalentsIndexJson) (
 	}
 
 	numTalents := len(index.PvpTalents)
-	requests := make(chan bnet.Request, numTalents)
+	requests := make(chan api.Request, numTalents)
 	results := make(chan scan.ScanResult[pvpTalentJson], numTalents)
 	options := scan.ScanOptions[pvpTalentJson]{
 		Validator: validator,
@@ -105,7 +105,7 @@ func getPvpTalentsFromIndex(scanner *scan.Scanner, index *pvpTalentsIndexJson) (
 	scan.Scan(scanner, requests, results, &options)
 
 	for _, talent := range index.PvpTalents {
-		apiRequest, err := bnet.RequestFromUrl(talent.Key.Href)
+		apiRequest, err := api.RequestFromUrl(talent.Key.Href)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse pvp talent url: %w", err)
 		}

--- a/pkg/retrieve/talents/pvp.go
+++ b/pkg/retrieve/talents/pvp.go
@@ -70,7 +70,7 @@ func getPvpTalentsIndex(scanner *scan.Scanner) (*pvpTalentsIndexJson, error) {
 
 	indexResult := scan.ScanSingle(
 		scanner,
-		api.Request{
+		api.BnetRequest{
 			Namespace: api.NamespaceStatic,
 			Region:    api.RegionUS,
 			Path:      "/data/wow/pvp-talent/index",
@@ -95,7 +95,7 @@ func getPvpTalentsFromIndex(scanner *scan.Scanner, index *pvpTalentsIndexJson) (
 	}
 
 	numTalents := len(index.PvpTalents)
-	requests := make(chan api.Request, numTalents)
+	requests := make(chan api.BnetRequest, numTalents)
 	results := make(chan scan.ScanResult[pvpTalentJson], numTalents)
 	options := scan.ScanOptions[pvpTalentJson]{
 		Validator: validator,

--- a/pkg/retrieve/talents/talents.go
+++ b/pkg/retrieve/talents/talents.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/hack"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/validate"
@@ -155,7 +155,7 @@ func getTreesFromSpecTrees(scanner *scan.Scanner, specLinks []SpecTreeLink) ([]w
 	}
 
 	numTrees := len(specLinks)
-	requests := make(chan bnet.Request, numTrees)
+	requests := make(chan api.Request, numTrees)
 	results := make(chan scan.ScanResult[talentTreeJson], numTrees)
 	options := scan.ScanOptions[talentTreeJson]{
 		Validator: validator,
@@ -166,7 +166,7 @@ func getTreesFromSpecTrees(scanner *scan.Scanner, specLinks []SpecTreeLink) ([]w
 
 	scan.Scan(scanner, requests, results, &options)
 	for _, specLink := range specLinks {
-		apiRequest, err := bnet.RequestFromUrl(specLink.Url)
+		apiRequest, err := api.RequestFromUrl(specLink.Url)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/retrieve/talents/talents.go
+++ b/pkg/retrieve/talents/talents.go
@@ -155,7 +155,7 @@ func getTreesFromSpecTrees(scanner *scan.Scanner, specLinks []SpecTreeLink) ([]w
 	}
 
 	numTrees := len(specLinks)
-	requests := make(chan api.Request, numTrees)
+	requests := make(chan api.BnetRequest, numTrees)
 	results := make(chan scan.ScanResult[talentTreeJson], numTrees)
 	options := scan.ScanOptions[talentTreeJson]{
 		Validator: validator,

--- a/pkg/retrieve/talents/tree_test.go
+++ b/pkg/retrieve/talents/tree_test.go
@@ -28,7 +28,7 @@ func TestGetTalentTree(t *testing.T) {
 
 	response := scan.ScanSingle(
 		scanner,
-		api.Request{
+		api.BnetRequest{
 			Namespace: api.NamespaceStatic,
 			Region:    api.RegionUS,
 			Path:      path,

--- a/pkg/retrieve/talents/tree_test.go
+++ b/pkg/retrieve/talents/tree_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/testutils"
 	"github.com/crbednarz/moonkinmetrics/pkg/validate"
@@ -28,9 +28,9 @@ func TestGetTalentTree(t *testing.T) {
 
 	response := scan.ScanSingle(
 		scanner,
-		bnet.Request{
-			Namespace: bnet.NamespaceStatic,
-			Region:    bnet.RegionUS,
+		api.Request{
+			Namespace: api.NamespaceStatic,
+			Region:    api.RegionUS,
 			Path:      path,
 		},
 		&scan.ScanOptions[talentTreeJson]{

--- a/pkg/scan/scanner.go
+++ b/pkg/scan/scanner.go
@@ -37,7 +37,7 @@ type ScanResultDetails struct {
 type ScanResult[T any] struct {
 	Response   T
 	Error      error
-	ApiRequest api.Request
+	ApiRequest api.BnetRequest
 	Index      int64
 	Details    ScanResultDetails
 }
@@ -50,7 +50,7 @@ type ScanOptions[T any] struct {
 }
 
 type indexedRequest struct {
-	ApiRequest api.Request
+	ApiRequest api.BnetRequest
 	Index      int64
 }
 
@@ -85,7 +85,7 @@ func NewScanner(storage storage.ResponseStorage, client *api.Client, opts ...Sca
 	}, nil
 }
 
-func Scan[T any](scanner *Scanner, requests <-chan api.Request, results chan<- ScanResult[T], options *ScanOptions[T]) {
+func Scan[T any](scanner *Scanner, requests <-chan api.BnetRequest, results chan<- ScanResult[T], options *ScanOptions[T]) {
 	ctx := context.TODO()
 	apiRequests := make(chan indexedRequest, cap(requests))
 	workerCount := min(max(1, cap(requests)), 100)
@@ -137,7 +137,7 @@ func Scan[T any](scanner *Scanner, requests <-chan api.Request, results chan<- S
 	}()
 }
 
-func ScanSingle[T any](scanner *Scanner, request api.Request, options *ScanOptions[T]) ScanResult[T] {
+func ScanSingle[T any](scanner *Scanner, request api.BnetRequest, options *ScanOptions[T]) ScanResult[T] {
 	ctx := context.TODO()
 
 	result := ScanResult[T]{
@@ -157,7 +157,7 @@ func ScanSingle[T any](scanner *Scanner, request api.Request, options *ScanOptio
 	return result
 }
 
-func buildFromCache[T any](ctx context.Context, scanner *Scanner, request api.Request, options *ScanOptions[T], result *ScanResult[T]) {
+func buildFromCache[T any](ctx context.Context, scanner *Scanner, request api.BnetRequest, options *ScanOptions[T], result *ScanResult[T]) {
 	cachedResponse, err := scanner.storage.Get(request)
 	if err != nil {
 		result.Error = err
@@ -178,7 +178,7 @@ func buildFromCache[T any](ctx context.Context, scanner *Scanner, request api.Re
 	}
 }
 
-func buildFromApi[T any](ctx context.Context, scanner *Scanner, request api.Request, options *ScanOptions[T], result *ScanResult[T]) {
+func buildFromApi[T any](ctx context.Context, scanner *Scanner, request api.BnetRequest, options *ScanOptions[T], result *ScanResult[T]) {
 	var lastError error
 	for i := 0; i < scanner.maxRetries; i++ {
 		lastError = nil

--- a/pkg/scan/scanner.go
+++ b/pkg/scan/scanner.go
@@ -182,7 +182,7 @@ func buildFromApi[T any](ctx context.Context, scanner *Scanner, request api.Bnet
 	var lastError error
 	for i := 0; i < scanner.maxRetries; i++ {
 		lastError = nil
-		apiResponse, err := scanner.client.Get(request)
+		apiResponse, err := scanner.client.Get(&request)
 		if err != nil {
 			lastError = fmt.Errorf("failed to retrieve response for %s: %w", request.Path, err)
 			continue

--- a/pkg/scan/scanner_test.go
+++ b/pkg/scan/scanner_test.go
@@ -68,8 +68,8 @@ func newMockScanner(httpClient *MockHttpClient) (*Scanner, error) {
 	)
 }
 
-func newMockRequest(path string) api.Request {
-	return api.Request{
+func newMockRequest(path string) api.BnetRequest {
+	return api.BnetRequest{
 		Region:    api.RegionUS,
 		Namespace: api.NamespaceProfile,
 		Path:      path,
@@ -153,7 +153,7 @@ func TestMultiScan(t *testing.T) {
 		t.Error(err)
 	}
 
-	requests := make(chan api.Request, 10)
+	requests := make(chan api.BnetRequest, 10)
 	results := make(chan ScanResult[MockResponseObject], 10)
 	options := newMockOptions[MockResponseObject]()
 
@@ -198,7 +198,7 @@ func TestCachedScan(t *testing.T) {
 		t.Error(err)
 	}
 
-	requests := make(chan api.Request)
+	requests := make(chan api.BnetRequest)
 	results := make(chan ScanResult[MockResponseObject])
 	options := newMockOptions[MockResponseObject]()
 
@@ -207,7 +207,7 @@ func TestCachedScan(t *testing.T) {
 	close(requests)
 	result := <-results
 
-	requests = make(chan api.Request)
+	requests = make(chan api.BnetRequest)
 	results = make(chan ScanResult[MockResponseObject])
 	Scan(scanner, requests, results, &options)
 	requests <- newMockRequest("/data/wow/mock/path")

--- a/pkg/scan/scanner_test.go
+++ b/pkg/scan/scanner_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/storage"
 	"github.com/crbednarz/moonkinmetrics/pkg/validate"
 )
@@ -49,13 +49,13 @@ func newMockScanner(httpClient *MockHttpClient) (*Scanner, error) {
 			ShouldFail:     false,
 		}
 	}
-	client := bnet.NewClient(
+	client := api.NewClient(
 		httpClient,
-		bnet.WithCredentials(
+		api.WithCredentials(
 			"mock_client_id",
 			"mock_client_secret",
 		),
-		bnet.WithLimiter(false),
+		api.WithLimiter(false),
 	)
 	cache, err := storage.NewSqlite(":memory:", storage.SqliteOptions{})
 	if err != nil {
@@ -68,10 +68,10 @@ func newMockScanner(httpClient *MockHttpClient) (*Scanner, error) {
 	)
 }
 
-func newMockRequest(path string) bnet.Request {
-	return bnet.Request{
-		Region:    bnet.RegionUS,
-		Namespace: bnet.NamespaceProfile,
+func newMockRequest(path string) api.Request {
+	return api.Request{
+		Region:    api.RegionUS,
+		Namespace: api.NamespaceProfile,
 		Path:      path,
 	}
 }
@@ -153,7 +153,7 @@ func TestMultiScan(t *testing.T) {
 		t.Error(err)
 	}
 
-	requests := make(chan bnet.Request, 10)
+	requests := make(chan api.Request, 10)
 	results := make(chan ScanResult[MockResponseObject], 10)
 	options := newMockOptions[MockResponseObject]()
 
@@ -198,7 +198,7 @@ func TestCachedScan(t *testing.T) {
 		t.Error(err)
 	}
 
-	requests := make(chan bnet.Request)
+	requests := make(chan api.Request)
 	results := make(chan ScanResult[MockResponseObject])
 	options := newMockOptions[MockResponseObject]()
 
@@ -207,7 +207,7 @@ func TestCachedScan(t *testing.T) {
 	close(requests)
 	result := <-results
 
-	requests = make(chan bnet.Request)
+	requests = make(chan api.Request)
 	results = make(chan ScanResult[MockResponseObject])
 	Scan(scanner, requests, results, &options)
 	requests <- newMockRequest("/data/wow/mock/path")

--- a/pkg/storage/sqlite.go
+++ b/pkg/storage/sqlite.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -38,7 +38,7 @@ func NewSqlite(path string, options SqliteOptions) (*Sqlite, error) {
 	return &Sqlite{db: db, options: options}, nil
 }
 
-func (s *Sqlite) Store(request bnet.Request, response []byte, lifespan time.Duration) error {
+func (s *Sqlite) Store(request api.Request, response []byte, lifespan time.Duration) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	now := time.Now()
@@ -92,7 +92,7 @@ func (s *Sqlite) StoreLinked(responses []Response, lifespan time.Duration) error
 	return tx.Commit()
 }
 
-func (s *Sqlite) Get(request bnet.Request) (StoredResponse, error) {
+func (s *Sqlite) Get(request api.Request) (StoredResponse, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 

--- a/pkg/storage/sqlite.go
+++ b/pkg/storage/sqlite.go
@@ -38,7 +38,7 @@ func NewSqlite(path string, options SqliteOptions) (*Sqlite, error) {
 	return &Sqlite{db: db, options: options}, nil
 }
 
-func (s *Sqlite) Store(request api.Request, response []byte, lifespan time.Duration) error {
+func (s *Sqlite) Store(request api.BnetRequest, response []byte, lifespan time.Duration) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	now := time.Now()
@@ -92,7 +92,7 @@ func (s *Sqlite) StoreLinked(responses []Response, lifespan time.Duration) error
 	return tx.Commit()
 }
 
-func (s *Sqlite) Get(request api.Request) (StoredResponse, error) {
+func (s *Sqlite) Get(request api.BnetRequest) (StoredResponse, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 

--- a/pkg/storage/sqlite_test.go
+++ b/pkg/storage/sqlite_test.go
@@ -6,16 +6,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 )
 
 func createMockResponses(count int) []Response {
 	responses := make([]Response, count)
 	for i := 0; i < count; i++ {
 		responses[i] = Response{
-			Request: bnet.Request{
-				Region:    bnet.RegionUS,
-				Namespace: bnet.NamespaceProfile,
+			Request: api.Request{
+				Region:    api.RegionUS,
+				Namespace: api.NamespaceProfile,
 				Path:      fmt.Sprintf("/data/wow/character/tichondrius/char%d", i),
 			},
 			Body: []byte(fmt.Sprintf("{\"value\": %d}}", i)),
@@ -30,9 +30,9 @@ func TestCanRetrieve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	request := bnet.Request{
-		Region:    bnet.RegionUS,
-		Namespace: bnet.NamespaceProfile,
+	request := api.Request{
+		Region:    api.RegionUS,
+		Namespace: api.NamespaceProfile,
 		Path:      "/data/wow/character/tichondrius/charactername",
 	}
 	response := []byte("{\"hello\": \"world\"}}")
@@ -58,9 +58,9 @@ func TestCanExpire(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	request := bnet.Request{
-		Region:    bnet.RegionUS,
-		Namespace: bnet.NamespaceProfile,
+	request := api.Request{
+		Region:    api.RegionUS,
+		Namespace: api.NamespaceProfile,
 		Path:      "/data/wow/character/tichondrius/charactername",
 	}
 	response := []byte("{\"hello\": \"world\"}}")
@@ -111,9 +111,9 @@ func TestCanReplace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	request := bnet.Request{
-		Region:    bnet.RegionUS,
-		Namespace: bnet.NamespaceProfile,
+	request := api.Request{
+		Region:    api.RegionUS,
+		Namespace: api.NamespaceProfile,
 		Path:      "/data/wow/character/tichondrius/charactername",
 	}
 	response := []byte("{\"value\": \"1\"}}")
@@ -185,9 +185,9 @@ func TestMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	request := bnet.Request{
-		Region:    bnet.RegionUS,
-		Namespace: bnet.NamespaceProfile,
+	request := api.Request{
+		Region:    api.RegionUS,
+		Namespace: api.NamespaceProfile,
 		Path:      "/data/wow/character/tichondrius/charactername",
 	}
 

--- a/pkg/storage/sqlite_test.go
+++ b/pkg/storage/sqlite_test.go
@@ -13,7 +13,7 @@ func createMockResponses(count int) []Response {
 	responses := make([]Response, count)
 	for i := 0; i < count; i++ {
 		responses[i] = Response{
-			Request: api.Request{
+			Request: api.BnetRequest{
 				Region:    api.RegionUS,
 				Namespace: api.NamespaceProfile,
 				Path:      fmt.Sprintf("/data/wow/character/tichondrius/char%d", i),
@@ -30,7 +30,7 @@ func TestCanRetrieve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	request := api.Request{
+	request := api.BnetRequest{
 		Region:    api.RegionUS,
 		Namespace: api.NamespaceProfile,
 		Path:      "/data/wow/character/tichondrius/charactername",
@@ -58,7 +58,7 @@ func TestCanExpire(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	request := api.Request{
+	request := api.BnetRequest{
 		Region:    api.RegionUS,
 		Namespace: api.NamespaceProfile,
 		Path:      "/data/wow/character/tichondrius/charactername",
@@ -111,7 +111,7 @@ func TestCanReplace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	request := api.Request{
+	request := api.BnetRequest{
 		Region:    api.RegionUS,
 		Namespace: api.NamespaceProfile,
 		Path:      "/data/wow/character/tichondrius/charactername",
@@ -185,7 +185,7 @@ func TestMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	request := api.Request{
+	request := api.BnetRequest{
 		Region:    api.RegionUS,
 		Namespace: api.NamespaceProfile,
 		Path:      "/data/wow/character/tichondrius/charactername",

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 )
 
 var ErrNotFound = errors.New("storage: not found")
@@ -16,7 +16,7 @@ type StoredResponse struct {
 
 type Response struct {
 	Body    []byte
-	Request bnet.Request
+	Request api.Request
 }
 
 type CleanResult struct {
@@ -25,13 +25,13 @@ type CleanResult struct {
 
 type ResponseStorage interface {
 	// Stores response for later retrieval by request.
-	Store(request bnet.Request, response []byte, lifespan time.Duration) error
+	Store(request api.Request, response []byte, lifespan time.Duration) error
 
 	// Stores set of responses, ensuring that all responses are stored or none are.
 	StoreLinked(responses []Response, lifespan time.Duration) error
 
 	// Retrieves a non-expired response for the given request.
-	Get(request bnet.Request) (StoredResponse, error)
+	Get(request api.Request) (StoredResponse, error)
 
 	// Cleans up expired responses.
 	Clean() (CleanResult, error)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,7 +16,7 @@ type StoredResponse struct {
 
 type Response struct {
 	Body    []byte
-	Request api.Request
+	Request api.BnetRequest
 }
 
 type CleanResult struct {
@@ -25,13 +25,13 @@ type CleanResult struct {
 
 type ResponseStorage interface {
 	// Stores response for later retrieval by request.
-	Store(request api.Request, response []byte, lifespan time.Duration) error
+	Store(request api.BnetRequest, response []byte, lifespan time.Duration) error
 
 	// Stores set of responses, ensuring that all responses are stored or none are.
 	StoreLinked(responses []Response, lifespan time.Duration) error
 
 	// Retrieves a non-expired response for the given request.
-	Get(request api.Request) (StoredResponse, error)
+	Get(request api.BnetRequest) (StoredResponse, error)
 
 	// Cleans up expired responses.
 	Clean() (CleanResult, error)

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 	"github.com/crbednarz/moonkinmetrics/pkg/scan"
 	"github.com/crbednarz/moonkinmetrics/pkg/storage"
 )
@@ -34,13 +34,13 @@ func (m *MockHttpClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 func NewMockScanner(callback MockClientCallback) (*scan.Scanner, error) {
-	client := bnet.NewClient(
+	client := api.NewClient(
 		&MockHttpClient{callback},
-		bnet.WithCredentials(
+		api.WithCredentials(
 			"mock_client_id",
 			"mock_client_secret",
 		),
-		bnet.WithLimiter(false),
+		api.WithLimiter(false),
 	)
 	cache, err := storage.NewSqlite(":memory:", storage.SqliteOptions{})
 	if err != nil {

--- a/pkg/wow/seasons.go
+++ b/pkg/wow/seasons.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/crbednarz/moonkinmetrics/pkg/bnet"
+	"github.com/crbednarz/moonkinmetrics/pkg/api"
 )
 
 type Leaderboard struct {
 	Bracket string
-	Region  bnet.Region
+	Region  api.Region
 	Entries []LeaderboardEntry
 }
 


### PR DESCRIPTION
This is a minor refactoring to help with support for other APIs (like warcraftlogs) in the future.